### PR TITLE
Add mono surround sound

### DIFF
--- a/audio/mixer_paths_tasha.xml
+++ b/audio/mixer_paths_tasha.xml
@@ -678,6 +678,13 @@
 <!-- #ifdef VENDOR_EDIT -->
 <!-- /*zhiguang.su@MultiMedia.AudioDrv , 2015/10/21, add for pa*/  -->
     <path name="deep-buffer-playback quat_i2s">
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia1" value="1" />
+        <ctl name="SLIM RX0 MUX" value="AIF_MIX1_PB" />
+        <ctl name="SLIM_0_RX Channels" value="One" />
+        <ctl name="RX INT0_1 MIX1 INP0" value="RX0" />
+        <ctl name="RX INT0 DEM MUX" value="CLSH_DSM_OUT" />
+        <ctl name="EAR PA Gain" value="G_8_DB" />
+        <ctl name="RX0 Digital Volume" value="95" />
         <ctl name="QUAT_MI2S_RX Audio Mixer MultiMedia1" value="1" />
     </path>
 <!--#endif   -->


### PR DESCRIPTION
This mod will activate you front earpiece speaker in conjunction with the bottom main speaker any time Speaker mode is used for example playing music, watching movies, shows, you tube and so on, creating an almost surround sound type of effect.
https://forum.xda-developers.com/oneplus-3/themes/mod-oneplus-3-audio-mods-t3407025